### PR TITLE
Correct LICENSE.md

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,3 @@
 # APBS and PDB2PQR licensing
 
-Both APBS and PDB2PQR are distributed under the [MIT open source license](https://choosealicense.com/licenses/mit/).  Please see the individual subdirectories for specific license information.
+Both APBS and PDB2PQR are distributed under the [BSD-3-Clause open source license](https://choosealicense.com/licenses/bsd-3-clause/).  Please see the individual subdirectories for specific license information.


### PR DESCRIPTION
The LICENSE.md file claims these are available under MIT but the text of both licence files is BSD-3-Clause.